### PR TITLE
Fixes #8 Deserialization process should not crash if the serializer is encountering an unknown NODE

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -5,6 +5,9 @@ on:
     branches:
     - main
 
+permissions:
+  packages: write
+
 env:
   MAJOR: 3
   MINOR: 0

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -9,7 +9,7 @@ permissions:
   packages: write
 
 env:
-  MAJOR: 3
+  MAJOR: 4
   MINOR: 0
   MINORMINOR: 1 
   RUN: ${{ github.run_number }}

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -6,7 +6,7 @@ on:
     - main
 
 env:
-  MAJOR: 3
+  MAJOR: 4
   MINOR: 0
   MINORMINOR: 1 
   RUN: ${{ github.run_number }}

--- a/OSPSuite.Serializer.sln
+++ b/OSPSuite.Serializer.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.12.35527.113 d17.12
+VisualStudioVersion = 17.12.35527.113
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OSPSuite.Serializer", "src\OSPSuite.Serializer\OSPSuite.Serializer.csproj", "{B2D4894C-47CE-44EE-A800-CE1CE7E0FE27}"
 EndProject
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OSPSuite.Serializer.Tests",
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{2FF430FB-3117-4D47-8405-DEEAA2D25110}"
 	ProjectSection(SolutionItems) = preProject
+		.github\workflows\build-and-publish.yml = .github\workflows\build-and-publish.yml
+		.github\workflows\build-pr.yml = .github\workflows\build-pr.yml
 		SolutionInfo.cs = SolutionInfo.cs
 	EndProjectSection
 EndProject

--- a/src/OSPSuite.Serializer/Xml/DynamicNodeMapper.cs
+++ b/src/OSPSuite.Serializer/Xml/DynamicNodeMapper.cs
@@ -19,7 +19,8 @@ namespace OSPSuite.Serializer.Xml
       public XObject Serialize(TObject objectToSerialize, TContext context)
       {
          var subObject = _propertyMap.ResolveValue(objectToSerialize);
-         if (subObject == null) return null;
+         if (subObject == null) 
+            return null;
 
          var serializer = _serializerRepository.SerializerFor(subObject);
          var subNode = serializer.Serialize(subObject, context);
@@ -35,6 +36,9 @@ namespace OSPSuite.Serializer.Xml
          var subNode = element.GetFirstElementWithAttribute(SerializerConstants.DynamicName, _propertyMap.Name);
          if (subNode == null) return;
          var serializer = _serializerRepository.SerializerFor(subNode);
+         if (serializer == null)
+            return;
+
          _propertyMap.SetValue(objectToDeserialize, serializer.Deserialize(subNode, context));
       }
    }

--- a/src/OSPSuite.Serializer/Xml/XmlCacheSerializer.cs
+++ b/src/OSPSuite.Serializer/Xml/XmlCacheSerializer.cs
@@ -35,12 +35,20 @@ namespace OSPSuite.Serializer.Xml
          foreach (var keyValueElement in cacheElement.Elements(KeyValueNode))
          {
             //not right format
-            if (keyValueElement.Elements().Count() < 2) continue;
+            if (keyValueElement.Elements().Count() < 2) 
+               continue;
+
             var keyNode = keyValueElement.Elements().ElementAt(0);
             var valueNode = keyValueElement.Elements().ElementAt(1);
 
-            var key = SerializerRepository.SerializerFor(keyNode).Deserialize<TKey>(keyNode, context);
-            var value = SerializerRepository.SerializerFor(valueNode).Deserialize<TValue>(valueNode, context);
+            var keySerializer = SerializerRepository.SerializerFor(keyNode);
+            var valueSerializer = SerializerRepository.SerializerFor(valueNode);
+
+            if(keySerializer == null || valueSerializer == null)
+               continue;
+
+            var key = keySerializer.Deserialize<TKey>(keyNode, context);
+            var value = valueSerializer.Deserialize<TValue>(valueNode, context);
             cache.Add(key, value);
          }
       }

--- a/src/OSPSuite.Serializer/Xml/XmlEnumerationNodeMapper.cs
+++ b/src/OSPSuite.Serializer/Xml/XmlEnumerationNodeMapper.cs
@@ -54,7 +54,9 @@ namespace OSPSuite.Serializer.Xml
 
          foreach (var childElement in entityListNode.Elements())
          {
-            addFunction(valueFromChildNode(childElement, context));
+            var value = valueFromChildNode(childElement, context);
+            if(value != null)
+               addFunction(value);
          }
       }
 
@@ -77,7 +79,7 @@ namespace OSPSuite.Serializer.Xml
             return childElement.Value.ConvertedTo<TProperty>();
 
          var serializer = _serializerRepository.SerializerFor(childElement);
-         return serializer.Deserialize<TProperty>(childElement, context);
+         return serializer == null ? default : serializer.Deserialize<TProperty>(childElement, context);
       }
    }
 }

--- a/src/OSPSuite.Serializer/Xml/XmlSerializerRepository.cs
+++ b/src/OSPSuite.Serializer/Xml/XmlSerializerRepository.cs
@@ -272,9 +272,7 @@ namespace OSPSuite.Serializer.Xml
       public IXmlSerializer<TContext> SerializerFor(XElement element)
       {
          var elementName = element.Name.LocalName;
-         var serializer = SerializerByKey(elementName);
-         if (serializer != null) return serializer;
-         throw new SerializerNotFoundException(elementName);
+         return SerializerByKey(elementName);
       }
 
       public XElement CreateElement(string elementName) => new XElement(Namespace + elementName);

--- a/tests/OSPSuite.Serializer.Tests/CacheXmlSerializerSpecs.cs
+++ b/tests/OSPSuite.Serializer.Tests/CacheXmlSerializerSpecs.cs
@@ -1,9 +1,11 @@
 using System.Drawing;
 using System.Linq;
+using System.Xml.Linq;
 using OSPSuite.BDDHelper;
 using OSPSuite.BDDHelper.Extensions;
 using OSPSuite.Serializer.Attributes;
 using OSPSuite.Serializer.Xml;
+using OSPSuite.Serializer.Xml.Extensions;
 using OSPSuite.Utility.Collections;
 using OSPSuite.Utility.Extensions;
 
@@ -46,6 +48,51 @@ namespace OSPSuite.Serializer.Tests
       protected override void Because()
       {
          var element = sut.Serialize(_cache, _context);
+         _deserialized = sut.Deserialize(element, _context).DowncastTo<ICache<Compound, Unit>>();
+      }
+
+      [Observation]
+      public void should_be_able_to_retrieve_the_cache()
+      {
+         _deserialized.ShouldNotBeNull();
+         _deserialized.Count().ShouldBeEqualTo(2);
+      }
+   }
+
+   public class When_deserializing_a_cache_object_with_unknown_key : concern_for_CacheXmlSerializer
+   {
+      private ICache<Compound, Unit> _deserialized;
+
+      protected override void Because()
+      {
+         var element = sut.Serialize(_cache, _context);
+         var newElement = new XElement("KeyValue");
+         newElement.AddElement(new XElement("unknown"));
+         newElement.AddElement(new XElement("Unit").AddAttribute("name", "mg").AddAttribute("color", "blue"));
+         
+         element.AddElement(newElement);
+         _deserialized = sut.Deserialize(element, _context).DowncastTo<ICache<Compound, Unit>>();
+      }
+
+      [Observation]
+      public void should_be_able_to_retrieve_the_cache()
+      {
+         _deserialized.ShouldNotBeNull();
+         _deserialized.Count.ShouldBeEqualTo(2);
+      }
+   }
+
+   public class When_deserializing_a_cache_object_with_unknown_value : concern_for_CacheXmlSerializer
+   {
+      private ICache<Compound, Unit> _deserialized;
+
+      protected override void Because()
+      {
+         var element = sut.Serialize(_cache, _context);
+         var newElement = new XElement("KeyValue");
+         newElement.AddElement(new XElement("Compound")).AddAttribute("id", 3).AddAttribute("name", "something").AddAttribute("compoundType", "base");
+         newElement.AddElement(new XElement("unknown"));
+         element.AddElement(newElement);
          _deserialized = sut.Deserialize(element, _context).DowncastTo<ICache<Compound, Unit>>();
       }
 

--- a/tests/OSPSuite.Serializer.Tests/DynamicNodeMapperSpecs.cs
+++ b/tests/OSPSuite.Serializer.Tests/DynamicNodeMapperSpecs.cs
@@ -1,0 +1,95 @@
+﻿using System.Xml.Linq;
+using FakeItEasy;
+using OSPSuite.BDDHelper;
+using OSPSuite.Serializer.Attributes;
+using OSPSuite.Serializer.Xml;
+using OSPSuite.Serializer.Xml.Extensions;
+
+namespace OSPSuite.Serializer.Tests
+{
+   internal class concern_for_DynamicNodeMapper : ContextSpecification<DynamicNodeMapper<DynamicObject, TestSerializationContext>>
+   {
+      private XmlSerializerRepository<TestSerializationContext> _serializerRepository;
+      private AttributeMapperRepository<TestSerializationContext> _attributeMapperRepository;
+      protected TestSerializationContext _context;
+      protected IPropertyMap _propertyMap;
+
+      protected override void Context()
+      {
+         base.Context();
+         _serializerRepository = new XmlSerializerRepository<TestSerializationContext>();
+         _attributeMapperRepository = new AttributeMapperRepository<TestSerializationContext>();
+         _attributeMapperRepository.AddDefaultAttributeMappers();
+         _serializerRepository.AddSerializer(new XmlEntitySerializer().WithRepositories(_serializerRepository, _attributeMapperRepository));
+         _context = new TestSerializationContext();
+         _propertyMap = A.Fake<IPropertyMap>();
+         sut = new DynamicNodeMapper<DynamicObject, TestSerializationContext>(_serializerRepository, _propertyMap);
+      }
+   }
+
+   internal class When_mapping_dynamic_node_and_the_node_is_unknown : concern_for_DynamicNodeMapper
+   {
+      private DynamicObject _objectToSerialize;
+      private object _subObject;
+      private XElement _element;
+      private DynamicObject _deserializedObject;
+
+      protected override void Context()
+      {
+         base.Context();
+         _subObject = new Entity();
+         _objectToSerialize = new DynamicObject();
+         A.CallTo(() => _propertyMap.ResolveValue(_objectToSerialize)).Returns(_subObject);
+         A.CallTo(() => _propertyMap.Name).Returns("subObject");
+         _element = new XElement("outer");
+         var xElement = (XElement)sut.Serialize(_objectToSerialize, _context);
+         xElement.Name = "unknown";
+         _element.AddElement(xElement);
+         _deserializedObject = new DynamicObject();
+      }
+
+      protected override void Because()
+      {
+         sut.Deserialize(_deserializedObject, _element, _context);
+      }
+
+      [Observation]
+      public void the_property_mapper_should_not_set_the_property()
+      {
+         A.CallTo(() => _propertyMap.SetValue(_deserializedObject, A<Entity>._)).MustNotHaveHappened();
+      }
+   }
+
+   internal class When_mapping_dynamic_node : concern_for_DynamicNodeMapper
+   {
+      private DynamicObject _objectToSerialize;
+      private object _subObject;
+      private XElement _element;
+      private DynamicObject _deserializedObject;
+
+      protected override void Context()
+      {
+         base.Context();
+         _subObject = new Entity();
+         _objectToSerialize = new DynamicObject();
+         A.CallTo(() => _propertyMap.ResolveValue(_objectToSerialize)).Returns(_subObject);
+         A.CallTo(() => _propertyMap.Name).Returns("subObject");
+         _element = new XElement("outer");
+         _element.AddElement((XElement)sut.Serialize(_objectToSerialize, _context));
+         _deserializedObject = new DynamicObject();
+      }
+
+      protected override void Because()
+      {
+         sut.Deserialize(_deserializedObject, _element, _context);
+      }
+
+      [Observation]
+      public void the_property_mapper_should_set_the_property()
+      {
+         A.CallTo(() => _propertyMap.SetValue(_deserializedObject, A<Entity>._)).MustHaveHappened();
+      }
+   }
+
+   internal class DynamicObject;
+}


### PR DESCRIPTION
Fixes #8
This crash should only happen when we are trying to get the serializer from the XElement it seems. So I only changed behavior where the XElement is used to find the serializer.

Not finding a serializer means that the element is ignored.

These are all used in adding to enumerables. And this funky DynamicNodeMapper.

In other cases, the serializers are resolved by mappers, so that means if XML without a mapper is included, it will be ignored already